### PR TITLE
updated to account for 3 start screens

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -97,6 +97,14 @@ module.exports = class Utilities {
     await statusScreen.HeaderSection.Devices.AddCGM();
   }
   async dismissTidepoolLogin() {
-    await match.accessible.Header("Tidepool").swipe('down', 'fast', 0.8)
+    try{
+      await match.accessible.Header("Tidepool").swipe('down', 'fast', 0.8);
+    } catch (e) {
+      try{
+      await match.accessible.Button('Cancel').tap();
+      } catch (e) {
+        return
+      }
+    }
   }
 };


### PR DESCRIPTION
On the most recent release there is no longer a tidepool login screen, on the dev branch upon opening the app there is the first page of therapy settings, then on release prior there is a tidepool login screen. I went ahead and tried to account for those 3 scenarios while the onboarding is being built. This will need to change again once the onboarding is finished.