### PR TITLE
account for no onboarding screen showing on ios13

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -97,14 +97,11 @@ module.exports = class Utilities {
     await statusScreen.HeaderSection.Devices.AddCGM();
   }
   async dismissTidepoolLogin() {
-    try{
-      await match.accessible.Header("Tidepool").swipe('down', 'fast', 0.8);
+    try {
+      await match.Label("Welcome_1_Top").swipe('down', 'fast', 0.8);
     } catch (e) {
-      try{
-      await match.accessible.Button('Cancel').tap();
-      } catch (e) {
-        return
-      }
+      console.log("onborading is not present on ios 13");
     }
+    return this;
   }
 };


### PR DESCRIPTION
on ios 13 no onboading is present so i simplified this to include either swiping down the onboarding screen (if it happens to appear) or doing nothing but logging info to the console. I have tested the current implementation and it runs fine locally on ios 13.

The alternative to this would be to just remove the `skipTidepoolLogin()` entirely while we are still running on ios 13 (since onboarding will NOT show up while running on ios 13). Let me know what you think.